### PR TITLE
Add support for Scaleway compute instances

### DIFF
--- a/lib/configurators/scaleway
+++ b/lib/configurators/scaleway
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Taken from nixos-infect
+# More info at: https://github.com/elitak/nixos-infect
+
+makeConfiguration() {
+
+  findmnt -n / -o partuuid >&2
+  rootfs=$(findmnt -n / -o partuuid)
+
+  cat << EOF
+{ ... }: {
+  imports = [
+    "\${nodeConf'.modulesPath}/profiles/qemu-guest.nix"
+  ];
+    fileSystems."/" = {
+      device = "/dev/disk/by-partuuid/${rootfs}";
+      autoResize = true;
+      fsType = "ext4";
+    };
+
+    fileSystems."/boot" = {
+      device = "/dev/disk/by-label/UEFI";
+      fsType = "vfat";
+    };
+
+    boot.growPartition = true;
+    boot.kernelParams = map (c: "console=\${c}") [ "ttyS0" ];
+    boot.loader.grub.device = "nodev";
+
+    boot.loader.grub.efiSupport = true;
+    boot.loader.grub.efiInstallAsRemovable = true;
+    boot.loader.timeout = 0;
+}
+EOF
+}
+
+makeConfiguration

--- a/lib/infect
+++ b/lib/infect
@@ -20,8 +20,33 @@ infect() {
   echo etc/resolv.conf            >> /etc/NIXOS_LUSTRATE
   echo root/.nix-defexpr/channels >> /etc/NIXOS_LUSTRATE
 
-  rm -rf /boot.bak
-  mv -v /boot /boot.bak
+  efivar=$(ls /sys/firmware/efi/efivars/LoaderDevicePartUUID* 2>/dev/null)
+  efipart=""
+  if [ -n "$efivar" ]; then
+    # read efi var using only "standard" utilities. first four bytes are attributes,
+    # followed by a utf-16 null-terminated string
+    efipart=$(dd if="$efivar" bs=1 skip=4 2>/dev/null | iconv -f utf16 | xargs -l -0)
+  fi
+  echo "efivar = $efivar" >&2
+  echo "efipart = $efipart" >&2
+  if findmnt /boot >/dev/null; then
+    cp -vr /boot /boot.bak
+    if findmnt /boot/efi >/dev/null; then
+      [ -z "$efipart" ] && efipart=$(findmnt -n /boot/efi -o partuuid)
+      echo "efipart = $efipart" >&2
+      umount /boot/efi
+    fi
+    umount /boot
+  else
+    mv -v /boot /boot.bak
+  fi
+
+  if [ -n "$efipart" ]; then
+    mkdir -p /boot
+    mount "/dev/disk/by-partuuid/$efipart" /boot
+  fi
+
+  ln -s "$(readlink -f /nix/var/nix/profiles/system)" /run/current-system
 
   /nix/var/nix/profiles/system/bin/switch-to-configuration boot
 }


### PR DESCRIPTION
This involves adding some generic UEFI support first. 

I've still got an error on push:
```
nixos-1> Error: Failed to reset failed units
nixos-1>
nixos-1> Caused by:
nixos-1>     Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.
```
But I think this is possibly due to nixiform's existing logic becoming out of step with modern NixOS - it seems to run `switch-to-configuration boot` and _then_ `switch-to-configuration switch`, and it's the latter that's breaking. Manual reboot seems to result in a working system anyway - I'm not sure we need the second invocation?

Opening this PR anyway as I've got go work on other things now and I thought this might be useful.